### PR TITLE
Feature/bulk task assignment

### DIFF
--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,0 +1,30 @@
+## Bulk Task Assignment Feature
+
+Hey team! I've added a new feature that allows assigning multiple tasks to a user at once. This will help make task management more efficient.
+
+### Changes Made
+- Added new endpoint `/tasks/bulk-assign/`
+- Created serializer for bulk assignment
+- Added view to handle the assignment logic
+- Updated URL routing
+
+### How to Use
+Send a POST request to `/tasks/bulk-assign/` with the following JSON:
+```json
+{
+    "task_ids": [1, 2, 3],
+    "user_id": 123
+}
+```
+
+The endpoint will assign all specified tasks to the given user and return a success message with the updated tasks.
+
+### Testing Done
+- Tested manually with Postman
+- Verified that tasks get assigned correctly
+- Checked that the API returns proper response
+
+### Notes
+- This is my first major feature, so any feedback is appreciated!
+- Let me know if you need any changes or have questions
+- I tried to keep it simple and straightforward

--- a/project_manager/serializers.py
+++ b/project_manager/serializers.py
@@ -38,3 +38,7 @@ class TaskSerializer(BaseSerializer):
     due_date = serializers.DateField()
     status = serializers.CharField()
 
+
+class BulkTaskAssignmentSerializer(serializers.Serializer):
+    task_ids = serializers.ListField(child=serializers.IntegerField())
+    user_id = serializers.IntegerField()

--- a/project_manager/urls.py
+++ b/project_manager/urls.py
@@ -13,6 +13,11 @@ project_urlpatterns = [
         api_views.TaskListAPIView.as_view(),
         name="tasks_list",
     ),
+    path(
+        "tasks/bulk-assign/",
+        api_views.BulkTaskAssignmentView.as_view(),
+        name="bulk_task_assignment",
+    ),
 ]
 
 urlpatterns = project_urlpatterns

--- a/project_manager/views.py
+++ b/project_manager/views.py
@@ -2,9 +2,13 @@ from rest_framework import status
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
+from django.contrib.auth.models import User
+from django.shortcuts import get_object_or_404
+
 from core.api.serializers import BaseListOutputSerializer
-from .serializers import ProjectSerializer, TaskSerializer
+from .serializers import ProjectSerializer, TaskSerializer, BulkTaskAssignmentSerializer
 from .services import ProjectsReadService, TasksReadService
+from .models import Task
 
 
 class ProjectListAPIView(APIView):
@@ -27,3 +31,29 @@ class TaskListAPIView(APIView):
         tasks = TasksReadService().list()
         output_data = self.TaskListOutputSerializer.get_output_data(tasks)
         return Response(output_data, status=status.HTTP_200_OK)
+
+
+class BulkTaskAssignmentView(APIView):
+    def post(self, request):
+        serializer = BulkTaskAssignmentSerializer(data=request.data)
+        if serializer.is_valid():
+            task_ids = serializer.validated_data['task_ids']
+            user_id = serializer.validated_data['user_id']
+            
+            # Get user
+            user = get_object_or_404(User, id=user_id)
+            
+            # Update all tasks
+            tasks = []
+            for task_id in task_ids:
+                task = Task.objects.get(id=task_id)
+                task.assigned_to = user
+                task.save()
+                tasks.append(task)
+            
+            # Return updated tasks
+            return Response({
+                'message': f'Successfully assigned {len(tasks)} tasks to {user.username}',
+                'tasks': TaskSerializer(tasks, many=True).data
+            })
+        return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
## Bulk Task Assignment Feature

Hey team! I've added a new feature that allows assigning multiple tasks to a user at once. This will help make task management more efficient.

### Changes Made
- Added new endpoint `/tasks/bulk-assign/`
- Created serializer for bulk assignment
- Added view to handle the assignment logic
- Updated URL routing

### How to Use
Send a POST request to `/tasks/bulk-assign/` with the following JSON:
```json
{
    "task_ids": [1, 2, 3],
    "user_id": 123
}
```

The endpoint will assign all specified tasks to the given user and return a success message with the updated tasks.

### Testing Done
- Tested manually with Postman
- Verified that tasks get assigned correctly
- Checked that the API returns proper response

### Notes
- This is my first major feature, so any feedback is appreciated!
- Let me know if you need any changes or have questions
- I tried to keep it simple and straightforward
